### PR TITLE
Exclude Call Routines from Namespace Exports

### DIFF
--- a/src/library/base/R/namespace.R
+++ b/src/library/base/R/namespace.R
@@ -715,9 +715,13 @@ loadNamespace <- function (package, lib.loc = NULL,
         }
         ## certain things should never be exported.
         if (length(exports)) {
+            callroutinelist <- unlist(lapply(env, function(obj)
+                if ("CallRoutine" %in% class(obj)) return(obj$name)
+            ), use.names = FALSE)
             stoplist <- c(".__NAMESPACE__.", ".__S3MethodsTable__.",
                           ".packageName", ".First.lib", ".onLoad",
-                          ".onAttach", ".conflicts.OK", ".noGenerics")
+                          ".onAttach", ".conflicts.OK", ".noGenerics",
+                          callroutinelist)
             exports <- exports[! exports %in% stoplist]
         }
         namespaceExport(ns, exports)


### PR DESCRIPTION
This branch is to remove Call Routines from the export list. This change should help resolve a few issue:

* Routine naming conventions no longer have to be aware of `exportPatterns()` in the namespace.
* Routine names can conflict with R object names without worrying about export conflicts.
* Allows for safer use of `.fixes=` parameter in `useDynLib()` (i.e. names may conflict after the fixes are attached.)